### PR TITLE
Bump node from v14 to v16

### DIFF
--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16'
           cache: npm
       - run: npm install -g npm@8
       - run: npm install

--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -11,13 +11,12 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: '16'
-          cache: npm
-      - run: npm install -g npm@8
-      - run: npm install
+          cache: 'yarn'
+      - run: yarn install --non-interactive --pure-lockfile
       - run: npx lint-to-the-future output -o lttfOutput --rootUrl `cut -d'/' -f2 <<< ${{ github.repository }}`${{ inputs.folder }} --previous-results https://${{ github.repository_owner }}.github.io/`cut -d'/' -f2 <<< ${{ github.repository }}`${{inputs.folder}}/data.json
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -12,11 +12,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8.6.6
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
-          cache: 'yarn'
-      - run: yarn install --non-interactive --pure-lockfile
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: 'Install dependencies'
+        run: pnpm install
+
       - run: npx lint-to-the-future output -o lttfOutput --rootUrl `cut -d'/' -f2 <<< ${{ github.repository }}`${{ inputs.folder }} --previous-results https://${{ github.repository_owner }}.github.io/`cut -d'/' -f2 <<< ${{ github.repository }}`${{inputs.folder}}/data.json
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
Hiya Chris! 👋🏻 

We have a lint-to-the-future workflow, which makes use of this lint-to-the-future-dashboard-action. Our workflow started to fail, and the error message pointed to this article: [GitHub Actions: All Actions will begin running on Node16 instead of Node12](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/). I forked this repo and tried bumping the version from `14` to `16`.

This didn't solve our problem, but it's probably worth doing all the same so here's a PR. 