### PR TITLE
get previous results with git - support github enterprise private pages out of the box

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,13 @@ runs:
             npm i 
           fi
       shell: bash
-    - run: npx lint-to-the-future output -o lttfOutput --rootUrl `cut -d'/' -f2 <<< ${{ github.repository }}`${{ inputs.folder }} --previous-results https://${{ github.repository_owner }}.github.io/`cut -d'/' -f2 <<< ${{ github.repository }}`${{inputs.folder}}/data.json
+    - name: Read previous Lttf data from the gh-pages branch
+      uses: actions/checkout@v4
+      with:
+        ref: gh-pages
+        sparse-checkout: lint-to-the-future/data.json
+        path: lttfTemp
+    - run: npx lint-to-the-future output -o ./lttfOutput --rootUrl `cut -d'/' -f2 <<< ${{ github.repository }}`${{ inputs.folder }} --previous-results lttfTemp/lint-to-the-future/data.json
       shell: bash
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
Fixes https://github.com/mansona/lttf-dashboard/issues/10

I tested this here: https://github.com/empress/ember-cli-showdown/pull/152 and it seems to work fine 👍 

